### PR TITLE
chore: add npm task `test` to run grunt-cli test

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,14 @@
   },
   "devDependencies": {
     "grunt": "~0.4",
+    "grunt-cli": "~0.1",
     "grunt-contrib-coffee": "*",
     "grunt-contrib-watch": "*",
     "grunt-contrib-uglify": "^0.9.2",
     "grunt-contrib-jasmine": "*",
     "grunt-browserify": "*"
+  },
+  "scripts": {
+    "test": "grunt test"
   }
 }


### PR DESCRIPTION
n.b.: this also adds grunt-cli as devDependency