### PR TITLE
fix(bower): Add license to our bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "main": "dist/modelize.min.js",
   "description": "Knockout.js REST and encryptable models",
   "homepage": "http://brainsware.org",
+  "license": "MIT",
   "author": "Daniel Khalil <d.khalil@brainsware.org>",
   "keywords": [
     "knockout",


### PR DESCRIPTION
it's not enough to have the license in the repository, it also needs to
be in the bower.json, to show up in the api (and hence in shields.io ;)
This fixes #6